### PR TITLE
fix: list when there's an error would blow up

### DIFF
--- a/scripts/list.js
+++ b/scripts/list.js
@@ -17,6 +17,9 @@ function info(txt) {
 function list(callback) {
   lambda.listFunctions({}, (err, fns)=> {
     console.log(chalk.green(' λ ') + chalk.grey.dim('listing deployed lambdas'))
+    if (err) {
+      return callback(err);
+    }
     var name = f=> f.FunctionName
     var start = name=> startsWith(name, filtering)
     var names = fns.Functions.map(name).filter(start).sort()

--- a/scripts/list.js
+++ b/scripts/list.js
@@ -18,7 +18,7 @@ function list(callback) {
   lambda.listFunctions({}, (err, fns)=> {
     console.log(chalk.green(' λ ') + chalk.grey.dim('listing deployed lambdas'))
     if (err) {
-      return callback(err);
+      return callback(err)
     }
     var name = f=> f.FunctionName
     var start = name=> startsWith(name, filtering)
@@ -57,6 +57,11 @@ function aliases(names, callback) {
 }
 
 async.waterfall([list, aliases], function complete(err, result) {
+  if (err) {
+    console.log(chalk.red(' λ ' + err.message))
+    return
+  }
+
   result.forEach(row=> {
     info(row.name)
     row.aliases.forEach(a=> {


### PR DESCRIPTION
Since `fns` response is `null` when there's an error in the `lambda.listFunctions`, the line `fns.Functions.map` blows up, since `Functions` prop is undefined (on `null`). So let's pass the error back early if it's there.

Note that I've not gone through all the calls to check this pattern exists, I just know that it causes problems both on `npm run list` and `npm run deploy ...`.

Example output:

<img width="679" alt="screen shot 2016-06-03 at 12 55 58" src="https://cloud.githubusercontent.com/assets/13700/15777877/8e3dea1c-298a-11e6-9c26-d2f9d427bd62.png">
