### PR TITLE
feat: default to node4.3 (plus configurable)

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -124,7 +124,7 @@ async.waterfall([
         FunctionName: package.json.name,
         Handler: 'index.handler',
         Role: package.json.lambda.role,
-        Runtime: 'nodejs',
+        Runtime: package.json.lambda.runtime || 'nodejs4.3',
         Publish: true,
         Timeout: 3
       }


### PR DESCRIPTION
Changes default deployed runtime to node@4.3 (instead of node@0.10 - because, seriously!!!).

It also adds support to read user property in `package.lambda.runtime`, so if they really do want node@0.10 they can. Though, I'm not sure it's worthwhile to document this functionality since AWS actually recommends you bump to the latest node.
